### PR TITLE
fix parsing of 920099 efact response

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/ReaderSession.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/ReaderSession.kt
@@ -40,8 +40,8 @@ class ReaderSession(reader: Reader) {
     fun peek(label: String, length: Int) = read(label, length).apply { reader.unread(length) }
 
     @Throws(IOException::class)
-    fun read(label: String, length: Int): String {
-        val chars = readChars(label, length)
+    fun read(label: String, length: Int, optional: Boolean = false): String {
+        val chars = readChars(label, length, optional)
         return String(chars)
     }
 
@@ -88,11 +88,15 @@ class ReaderSession(reader: Reader) {
     fun peekChars(label: String, length: Int) = readChars(label, length).apply { reader.unread(length) }
 
     @Throws(IOException::class)
-    private fun readChars(label: String, length: Int): CharArray {
+    private fun readChars(label: String, length: Int, optional: Boolean = false): CharArray {
         val chars = CharArray(length)
         val readChars = reader.read(chars)
         if (readChars < length) {
-            throw EOFException("Not enough characters left to read $length characters from the field '$label'")
+            if (optional) {
+                chars.fill(' ')
+            } else {
+                throw EOFException("Not enough characters left to read $length characters from the field '$label'")
+            }
         }
         return chars
     }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatReader.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/BelgianInsuranceInvoicingFormatReader.kt
@@ -59,6 +59,7 @@ class BelgianInsuranceInvoicingFormatReader(private val language: String) {
     @Throws(IOException::class)
     fun parse(reader: Reader, parseErrors: Boolean = true): List<Record<*>>? {
         val session = ReaderSession(reader)
+        var doParseErrors = parseErrors
         return mutableListOf<Record<*>>().apply {
             var i = 0
             loop@ while(true) {
@@ -70,6 +71,7 @@ class BelgianInsuranceInvoicingFormatReader(private val language: String) {
                         "00" -> {
                             this.add(Record(Segment200Description, Segment200Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
                             if (messageType.substring(2, 6) == "0999" || messageType.substring(2, 6) == "0000") {
+                                doParseErrors = false
                                 this.add(Record(Segment300Description, Segment300Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
                             } else if (messageType.substring(2, 6) == "1000") {
                                 this.add(Record(Segment300StubDescription, Segment300StubDescription.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
@@ -78,20 +80,20 @@ class BelgianInsuranceInvoicingFormatReader(private val language: String) {
                             }
 
                         }
-                        "10" -> this.add(Record(Record10Description, Record10Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "20" -> this.add(Record(Record20Description, Record20Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "30" -> this.add(Record(Record30Description, Record30Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "50" -> this.add(Record(Record50Description, Record50Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "51" -> this.add(Record(Record51Description, Record51Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "52" -> this.add(Record(Record52Description, Record52Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "80" -> this.add(Record(Record80Description, Record80Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
-                        "90" -> this.add(Record(Record90Description, Record90Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (parseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "10" -> this.add(Record(Record10Description, Record10Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "20" -> this.add(Record(Record20Description, Record20Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "30" -> this.add(Record(Record30Description, Record30Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "50" -> this.add(Record(Record50Description, Record50Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "51" -> this.add(Record(Record51Description, Record51Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "52" -> this.add(Record(Record52Description, Record52Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "80" -> this.add(Record(Record80Description, Record80Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
+                        "90" -> this.add(Record(Record90Description, Record90Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }).apply { if (doParseErrors) this.errorDetail = readErrorDetails(session, this) })
 
                         "91" -> this.add(Record(Segment400Record91Description, Segment400Record91Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
                         "92" -> this.add(Record(Segment500Record92Description, Segment500Record92Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
 
                         "95" -> this.add(Record(Segment400Record95Description, Segment400Record95Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
-                        "96" -> this.add(Record(Segment500Record96Description, Segment500Record96Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length)) }))
+                        "96" -> this.add(Record(Segment500Record96Description, Segment500Record96Description.zoneDescriptions.map { zd -> Zone(zd, session.read(zd.label, zd.length, zd.optional)) }))
                         else -> break@loop
                     }
                 } catch (e: EOFException) {

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/RecordOrSegmentDescription.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/RecordOrSegmentDescription.kt
@@ -40,8 +40,9 @@ abstract class RecordOrSegmentDescription {
                            position: Int,
                            length: Int,
                            value: String? = null,
-                           cs: Boolean = false): Int {
-        val zoneDescription = ZoneDescription.build(zones, label, typeSymbol, position, length, value, cs)
+                           cs: Boolean = false,
+                           optional: Boolean = false): Int {
+        val zoneDescription = ZoneDescription.build(zones, label, typeSymbol, position, length, value, cs, optional)
         for (zone in zones.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()) {
             zoneDescriptionsByZone[zone.trim { it <= ' ' }] = zoneDescription
         }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Segment500Record96Description.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/Segment500Record96Description.kt
@@ -30,7 +30,7 @@ object Segment500Record96Description : RecordOrSegmentDescription() {
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5091", "Code erreur", "N", pos, 2)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "510", "Lien T90 Z98 N controle envoi", "N", pos, 2)
         pos = register(ZONE_DESCRIPTIONS_BY_ZONE, "5101", "Code erreur", "N", pos, 2)
-              register(ZONE_DESCRIPTIONS_BY_ZONE, "511", "Reserve", "A", pos, 271)
+              register(ZONE_DESCRIPTIONS_BY_ZONE, "511", "Reserve", "A", pos, 271, null, false, true)
     }
 
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/ZoneDescription.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/format/efact/segments/ZoneDescription.kt
@@ -27,7 +27,8 @@ class ZoneDescription private constructor(val label: String,
                                           val type: ZoneType,
                                           val zones: List<String>,
                                           val value: String? = null,
-                                          val cs: Boolean = false) {
+                                          val cs: Boolean = false,
+                                          val optional: Boolean = false) {
     var zonesList: String? = null
         get() = field ?: StringUtils.join(zones, ",")
 
@@ -56,11 +57,12 @@ class ZoneDescription private constructor(val label: String,
                   position: Int,
                   length: Int,
                   value: String? = null,
-                  cs: Boolean = false): ZoneDescription {
+                  cs: Boolean = false,
+                  optional: Boolean = false): ZoneDescription {
             val type = ZoneType.fromSymbol(typeSymbol) ?: throw IllegalArgumentException("Invalid type $typeSymbol")
             val splitZones = commaSeparatedZones.split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
             val zones = splitZones.map { it.trim { it <= ' ' } }
-            return ZoneDescription(label, position, length, type, zones, value, cs)
+            return ZoneDescription(label, position, length, type, zones, value, cs, optional)
         }
     }
 }


### PR DESCRIPTION
## Current behaviour

- When a 920999 response is received, it tries to add `errorDetail` for ET10. This moves the `index` of the reader to a wrong value, leading to bad reading of the rest of the eFact message (in our case, zone200, zone300, ET10, zone200, zone300,... with `errorDetail` containing data about the ET20 and so on).

- When a 920999 response is received, sometimes the last zone of the ET96 is unavailable (trimmed?) which leads to a `EOFException`, which breaks the loop of parsing such that the parsed message does not contain the ET96 data.

## New behaviour

- When a 920999 response is received, no errorDetails is created.

- In a 920999, we made the last zone of the ET96 optional, such that if it is not present we still return the ET96 data (with this zone containing only blank char)