### PR TITLE
Fix ehbox message DTO mapping order and remove duplicate

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/mapper/MessageMapper.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/mapper/MessageMapper.kt
@@ -36,10 +36,9 @@ import java.time.temporal.ChronoUnit
 
 fun <T> Message<T>.toMessageDto(): org.taktik.freehealth.middleware.dto.ehbox.Message? = when {
     this is NewsMessage -> this.toNewsMessage()
-    this is DocumentMessage -> this.toDocumentMessage()
     this is AcknowledgeMessage -> this.toAcknowledgeMessage()
-    this is ErrorMessage -> this.toErrorMessage()
     this is DocumentMessage -> this.toDocumentMessage()
+    this is ErrorMessage -> this.toErrorMessage()
     else -> null
 }
 


### PR DESCRIPTION
Actually, the message was never mapped to `AcknowledgeMessage` since its parent (through inheritance), `DocumentMessage`, is processed before its child. The parent should be processed after its children for avoiding issues.

In addition, the `DocumentMessage` case had been duplicated. I removed unnecessary one.