### PR TITLE
fix ehbox error mgt

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EhboxServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EhboxServiceImpl.kt
@@ -94,7 +94,7 @@ class EhboxServiceImpl(private val stsService: STSService, keyDepotService: KeyD
         }
         val msg = freehealthEhboxService.getFullMessage(samlToken, messageRequest)
 
-        return if (msg.status?.code != "100") try { consultationMessageBuilder.buildFullMessage(
+        return if (msg.status?.code == "100") try { consultationMessageBuilder.buildFullMessage(
             KeyStoreCredential(keystoreId, stsService.getKeyStore(keystoreId, passPhrase)!!, "authentication", passPhrase), msg).toMessageDto()?.let { MessageResponse(it) } ?: MessageResponse(null, Error("Unknown error")) } catch (e:EhboxCryptoException) {
             alternateKeystores?.mapFirstNotNull {
                 try { it.uuid?.let { uuid -> it.passPhrase?.let { pass -> consultationMessageBuilder.buildFullMessage(KeyStoreCredential(uuid, stsService.getKeyStore(uuid, pass)!!, "authentication", pass), msg).toMessageDto() }}} catch(_: EhboxCryptoException) { null }


### PR DESCRIPTION
`(msg.status?.code == "100")` means  `SUCCESS`

There are 2 other places where the condition is tested, and they should be checked. See https://github.com/taktik/freehealth-connector/commit/47b2ff729f32d0f2f7a54df6f9d25e785f219761