### PR TITLE
Fix exception handling

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/SwaggerConfiguration.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/SwaggerConfiguration.kt
@@ -34,5 +34,10 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2
 class SwaggerConfiguration {
     @Bean
     fun api(): Docket =
-        Docket(DocumentationType.SWAGGER_2).securitySchemes(listOf(BasicAuth("basicAuth"))).select().apis(RequestHandlerSelectors.any()).paths(PathSelectors.any()).build()
+        Docket(DocumentationType.SWAGGER_2)
+            .securitySchemes(listOf(BasicAuth("basicAuth")))
+            .select()
+            .apis(RequestHandlerSelectors.basePackage("org.taktik"))
+            .paths(PathSelectors.any())
+            .build()
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/WebMvcConfigurer.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/WebMvcConfigurer.kt
@@ -6,13 +6,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity
-import org.springframework.web.servlet.HandlerExceptionResolver
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer
 import org.springframework.web.servlet.config.annotation.EnableWebMvc
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
-import org.taktik.freehealth.middleware.web.ExceptionHandlers
 
 @Configuration
 @EnableWebMvc
@@ -21,10 +19,6 @@ import org.taktik.freehealth.middleware.web.ExceptionHandlers
 @EnableConfigurationProperties(ServerProperties::class, ResourceProperties::class)
 class WebMvcConfigurer(val resourceProperties: ResourceProperties) : WebMvcConfigurer {
     private val SERVLET_LOCATIONS = arrayOf("/")
-
-    override fun configureHandlerExceptionResolvers(exceptionResolvers: MutableList<HandlerExceptionResolver>) {
-        exceptionResolvers.add(ExceptionHandlers());
-    }
 
     override fun configureContentNegotiation(contentNegotiationConfigurer: ContentNegotiationConfigurer) {
         // Disable use of pathExtension and parameter for content negotiation

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -1,53 +1,31 @@
 package org.taktik.freehealth.middleware.web
 
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.web.servlet.ModelAndView
-import org.springframework.web.servlet.handler.AbstractHandlerExceptionResolver
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.taktik.connector.technical.exception.TechnicalConnectorException
 import org.taktik.freehealth.middleware.exception.MissingKeystoreException
 import org.taktik.freehealth.middleware.exception.MissingTokenException
-
-import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
-import java.io.IOException
-import java.util.concurrent.ExecutionException
+import javax.xml.ws.soap.SOAPFaultException
 
 /**
  * Improve this using ResponseStatusException when upgrading to Spring 5+
  */
-class ExceptionHandlers : AbstractHandlerExceptionResolver() {
-    override fun doResolveException(httpServletRequest: HttpServletRequest, httpServletResponse: HttpServletResponse, handler: Any?, exception: Exception): ModelAndView? {
-        try {
-            val rootException : Exception = if (exception is ExecutionException && exception.cause is java.lang.Exception) exception.cause as Exception else exception
-
-            if (rootException is TechnicalConnectorException) {
-                return handleTechnicalConnectorException(rootException, httpServletResponse)
-            } else if (rootException is MissingKeystoreException) {
-                return handleUnauthorizedException(rootException.message, httpServletResponse)
-            } else if (rootException is MissingTokenException) {
-                return handleUnauthorizedException(rootException.message, httpServletResponse)
-            }
-        } catch (handlerException: Exception) {
-            logger.error("Handling of [" + exception.javaClass.name + "]	resulted in Exception", handlerException)
-        }
-
-        return null
+@ControllerAdvice
+class ExceptionHandlers {
+    @ExceptionHandler(TechnicalConnectorException::class)
+    fun handleTechnicalConnectorException(response: HttpServletResponse, exception: TechnicalConnectorException) {
+        response.sendError(exception.category.httpStatus.value(), exception.message ?: "unknown reason")
     }
 
-    @Throws(IOException::class)
-    private fun handleTechnicalConnectorException(exception: TechnicalConnectorException, httpServletResponse: HttpServletResponse): ModelAndView? {
-        httpServletResponse.contentType = MediaType.TEXT_PLAIN_VALUE
-        httpServletResponse.sendError(exception.category.httpStatus.value(), exception.message)
-
-        return null
+    @ExceptionHandler(MissingKeystoreException::class, MissingTokenException::class)
+    fun handleUnauthorizedException(response: HttpServletResponse, exception: Exception) {
+        response.sendError(HttpStatus.UNAUTHORIZED.value(), exception.message ?: "unknown reason")
     }
 
-    @Throws(IOException::class)
-    private fun handleUnauthorizedException(message: String?, httpServletResponse: HttpServletResponse): ModelAndView? {
-        httpServletResponse.contentType = MediaType.TEXT_PLAIN_VALUE
-        httpServletResponse.sendError(HttpStatus.UNAUTHORIZED.value(), message ?: "Unknown error")
-
-        return null
+    @ExceptionHandler(SOAPFaultException::class)
+    fun handleSoapFaultException(response: HttpServletResponse, exception: SOAPFaultException) {
+        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message ?: "unknown reason")
     }
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/ExceptionHandlers.kt
@@ -14,18 +14,22 @@ import javax.xml.ws.soap.SOAPFaultException
  */
 @ControllerAdvice
 class ExceptionHandlers {
+    companion object {
+        private const val DEFAULT_EXCEPTION_MESSAGE = "unknown reason";
+    }
+
     @ExceptionHandler(TechnicalConnectorException::class)
     fun handleTechnicalConnectorException(response: HttpServletResponse, exception: TechnicalConnectorException) {
-        response.sendError(exception.category.httpStatus.value(), exception.message ?: "unknown reason")
+        response.sendError(exception.category.httpStatus.value(), exception.message ?: DEFAULT_EXCEPTION_MESSAGE)
     }
 
     @ExceptionHandler(MissingKeystoreException::class, MissingTokenException::class)
     fun handleUnauthorizedException(response: HttpServletResponse, exception: Exception) {
-        response.sendError(HttpStatus.UNAUTHORIZED.value(), exception.message ?: "unknown reason")
+        response.sendError(HttpStatus.UNAUTHORIZED.value(), exception.message ?: DEFAULT_EXCEPTION_MESSAGE)
     }
 
     @ExceptionHandler(SOAPFaultException::class)
     fun handleSoapFaultException(response: HttpServletResponse, exception: SOAPFaultException) {
-        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message ?: "unknown reason")
+        response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value(), exception.message ?: DEFAULT_EXCEPTION_MESSAGE)
     }
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/AddressbookController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/AddressbookController.kt
@@ -20,30 +20,15 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.HealthcareParty
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.AddressbookService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/ab")
 class AddressbookController(val addressbookService: AddressbookService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
     @GetMapping("/search/hcp/{lastName}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun searchHcp(
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/Chapter4Controller.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/Chapter4Controller.kt
@@ -20,16 +20,10 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
+import org.apache.commons.io.IOUtils
 import org.slf4j.LoggerFactory
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
 import org.taktik.connector.business.domain.chapter4.Appendix
 import org.taktik.connector.business.domain.chapter4.RequestType
 import org.taktik.freehealth.middleware.drugs.civics.AddedDocumentPreview
@@ -37,28 +31,15 @@ import org.taktik.freehealth.middleware.drugs.civics.ParagraphInfos
 import org.taktik.freehealth.middleware.drugs.civics.ParagraphPreview
 import org.taktik.freehealth.middleware.drugs.dto.MppPreview
 import org.taktik.freehealth.middleware.service.Chapter4Service
+import java.net.URL
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.*
 import javax.servlet.http.HttpServletResponse
-import org.apache.commons.io.IOUtils
-import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.taktik.freehealth.middleware.exception.MissingTokenException
-import java.net.URL
-import javax.servlet.http.HttpServletRequest
-
 
 @RestController
 @RequestMapping("/chap4")
 class Chapter4Controller(private val chapter4Service: Chapter4Service) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
     val log = LoggerFactory.getLogger(this .javaClass)
 
     @GetMapping("/sam/docpreviews/{chapterName}/{paragraphName}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/ConsentController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/ConsentController.kt
@@ -22,41 +22,17 @@ package org.taktik.freehealth.middleware.web.controllers
 
 import be.fgov.ehealth.hubservices.core.v2.ConsentType
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.consent.ConsentMessageDto
 import org.taktik.freehealth.middleware.dto.consent.ConsentTypeDto
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.ConsentService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/consent")
 class ConsentController(val consentService: ConsentService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("/{patientSsin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("/{patientSsin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun registerPatientConsent(
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,
         @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/ConsultrnController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/ConsultrnController.kt
@@ -23,46 +23,21 @@ package org.taktik.freehealth.middleware.web.controllers
 import be.fgov.ehealth.consultrn.commons.core.v3.BusinessAnomalyType
 import be.fgov.ehealth.consultrn.protocol.v2.RegisterPersonResponse
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.connector.business.consultrn.exception.manageperson.ConsultrnRegisterExistingPersonException
 import org.taktik.connector.business.consultrn.exception.manageperson.ConsultrnRegisterPersonException
 import org.taktik.freehealth.middleware.dto.consultrn.PersonMid
 import org.taktik.freehealth.middleware.dto.consultrn.RegisterPersonResponseDto
 import org.taktik.freehealth.middleware.dto.consultrn.SearchBySSINReplyDto
 import org.taktik.freehealth.middleware.dto.consultrn.SearchPhoneticReplyDto
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.ConsultRnService
-import java.util.UUID
-import javax.servlet.http.HttpServletRequest
-import javax.websocket.server.PathParam
+import java.util.*
 
 @RestController
 @RequestMapping("/consultrn")
 class ConsultrnController(val consultRnService: ConsultRnService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@GetMapping("/{ssin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @GetMapping("/{ssin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun identify(
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,
         @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/CryptoController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/CryptoController.kt
@@ -20,41 +20,18 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.taktik.connector.business.ehbox.api.domain.Addressee
 import org.taktik.connector.technical.utils.IdentifierType
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.CryptoService
-import java.util.UUID
-import javax.servlet.http.HttpServletRequest
+import java.util.*
 
 @RestController
 @RequestMapping("/crypto")
 class CryptoController(val cryptoService: CryptoService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("/encrypt/{identifier}/{id}", consumes = [MediaType.APPLICATION_OCTET_STREAM_VALUE], produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("/encrypt/{identifier}/{id}", consumes = [MediaType.APPLICATION_OCTET_STREAM_VALUE], produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun encrypt(
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,
         @RequestHeader(name = "X-FHC-passPhrase") passPhrase: String,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/DmgController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/DmgController.kt
@@ -1,40 +1,16 @@
 package org.taktik.freehealth.middleware.web.controllers
 
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.common.GenAsyncResponse
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.DmgService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/gmd")
 class DmgController(val dmgService: DmgService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("/register/{oa}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("/register/{oa}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun registerDoctor(@RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID, @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID, @RequestHeader(name = "X-FHC-passPhrase") passPhrase: String, @RequestParam hcpNihii: String, @RequestParam hcpSsin: String, @RequestParam hcpFirstName: String, @RequestParam hcpLastName: String, @PathVariable oa: String, @RequestParam bic: String, @RequestParam iban: String) =
         dmgService.registerDoctor(keystoreId = keystoreId, tokenId = tokenId, passPhrase = passPhrase, hcpNihii = hcpNihii, hcpSsin = hcpSsin, hcpFirstName = hcpFirstName, hcpLastName = hcpLastName, oa = oa, bic = bic, iban = iban)
 

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EattestController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EattestController.kt
@@ -20,39 +20,17 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.eattest.Eattest
 import org.taktik.freehealth.middleware.dto.eattest.SendAttestResult
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.EattestService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/eattest")
 class EattestController(val eattestService: EattestService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("/send/{patientSsin}/verbose", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("/send/{patientSsin}/verbose", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun sendAttestWithResponse(
         @PathVariable patientSsin: String,
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EfactController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EfactController.kt
@@ -21,41 +21,16 @@
 package org.taktik.freehealth.middleware.web.controllers
 
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.efact.InvoicesBatch
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.EfactService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/efact")
 class EfactController(val efactService: EfactService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("/batch", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("/batch", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun sendBatch(
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,
         @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EhboxController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EhboxController.kt
@@ -20,44 +20,16 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
-import org.taktik.freehealth.middleware.dto.ehbox.AltKeystoresList
-import org.taktik.freehealth.middleware.dto.ehbox.BoxInfo
-import org.taktik.freehealth.middleware.dto.ehbox.DocumentMessage
-import org.taktik.freehealth.middleware.dto.ehbox.ErrorMessage
-import org.taktik.freehealth.middleware.dto.ehbox.Message
-import org.taktik.freehealth.middleware.exception.MissingTokenException
+import org.springframework.web.bind.annotation.*
+import org.taktik.freehealth.middleware.dto.ehbox.*
 import org.taktik.freehealth.middleware.service.EhboxService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/ehbox")
 class EhboxController(val ehboxService: EhboxService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@GetMapping("", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @GetMapping("", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun getInfos(@RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID, @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID, @RequestHeader(name = "X-FHC-passPhrase") passPhrase: String): BoxInfo =
         ehboxService.getInfos(keystoreId, tokenId, passPhrase)
 

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EhboxV3Controller.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/EhboxV3Controller.kt
@@ -20,46 +20,16 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
-import org.taktik.freehealth.middleware.dto.ehbox.AltKeystoresList
-import org.taktik.freehealth.middleware.dto.ehbox.BoxInfo
-import org.taktik.freehealth.middleware.dto.ehbox.DocumentMessage
-import org.taktik.freehealth.middleware.dto.ehbox.Message
-import org.taktik.freehealth.middleware.dto.ehbox.MessageOperationResponse
-import org.taktik.freehealth.middleware.dto.ehbox.MessageResponse
-import org.taktik.freehealth.middleware.dto.ehbox.MessagesResponse
-import org.taktik.freehealth.middleware.exception.MissingTokenException
+import org.springframework.web.bind.annotation.*
+import org.taktik.freehealth.middleware.dto.ehbox.*
 import org.taktik.freehealth.middleware.service.EhboxService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/ehboxV3")
 class EhboxV3Controller(val ehboxService: EhboxService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@GetMapping("", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @GetMapping("", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun getInfos(@RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID, @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID, @RequestHeader(name = "X-FHC-passPhrase") passPhrase: String): BoxInfo =
         ehboxService.getInfos(keystoreId, tokenId, passPhrase)
 

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/ErrorController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/ErrorController.kt
@@ -1,0 +1,43 @@
+package org.taktik.freehealth.middleware.web.controllers
+
+import org.apache.commons.lang3.StringUtils
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.web.ServerProperties
+import org.springframework.boot.autoconfigure.web.servlet.error.AbstractErrorController
+import org.springframework.boot.autoconfigure.web.servlet.error.ErrorViewResolver
+import org.springframework.boot.web.servlet.error.ErrorAttributes
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import springfox.documentation.annotations.ApiIgnore
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * Replaces BasicErrorController to return error message as plain text instead of html or json.
+ */
+@ConditionalOnProperty("server.error.type", havingValue = "plain", matchIfMissing = true)
+@ApiIgnore
+@Controller
+@RequestMapping("\${server.error.path:\${error.path:/error}}")
+class ErrorController(
+    val errorAttributes: ErrorAttributes,
+    val serverProperties: ServerProperties,
+    errorViewResolvers: List<ErrorViewResolver>? = null
+) : AbstractErrorController(errorAttributes, errorViewResolvers) {
+    override fun getErrorPath(): String {
+        return serverProperties.error.path
+    }
+
+    @RequestMapping(produces = ["${MediaType.TEXT_PLAIN_VALUE};charset=UTF-8"])
+    @ResponseBody
+    fun errorString(request: HttpServletRequest, response: HttpServletResponse): ResponseEntity<String> {
+        val status = getStatus(request)
+        val body = getErrorAttributes(request, false)
+        val message = body["message"]?.toString() ?: StringUtils.EMPTY
+
+        return ResponseEntity(message, status)
+    }
+}

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/GenInsController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/GenInsController.kt
@@ -20,39 +20,17 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.genins.InsurabilityInfoDto
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.GenInsService
 import java.time.Instant
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/genins")
 class GenInsController(val genInsService: GenInsService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@GetMapping("/{ssin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @GetMapping("/{ssin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun getGeneralInsurability(
         @PathVariable ssin: String,
         @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/HubController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/HubController.kt
@@ -20,36 +20,25 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import be.fgov.ehealth.hubservices.core.v3.GetAccessRightResponse
-import be.fgov.ehealth.hubservices.core.v3.GetPatientAuditTrailResponse
-import be.fgov.ehealth.hubservices.core.v3.PutAccessRightResponse
-import be.fgov.ehealth.hubservices.core.v3.PutTransactionSetResponse
-import be.fgov.ehealth.hubservices.core.v3.RevokeAccessRightResponse
+import be.fgov.ehealth.hubservices.core.v3.*
 import be.fgov.ehealth.standards.kmehr.schema.v1.Kmehrmessage
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
 import org.taktik.connector.technical.utils.MarshallerHelper
 import org.taktik.freehealth.middleware.domain.consent.Consent
-import org.taktik.freehealth.middleware.dto.hub.TransactionSummaryDto
 import org.taktik.freehealth.middleware.dto.common.Gender
 import org.taktik.freehealth.middleware.dto.hub.PutTransactionResponseDto
+import org.taktik.freehealth.middleware.dto.hub.TransactionSummaryDto
 import org.taktik.freehealth.middleware.dto.therlink.TherapeuticLinkMessageDto
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.HubService
 import org.taktik.freehealth.utils.FuzzyValues
 import java.time.Instant
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/hub")
 class HubController(val hubService: HubService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
     @PostMapping("/patient/{lastName}/{patientSsin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun putPatient(
         @RequestParam endpoint: String,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/MemberDataController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/MemberDataController.kt
@@ -22,33 +22,18 @@ package org.taktik.freehealth.middleware.web.controllers
 
 import ma.glasnost.orika.MapperFacade
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
-import org.taktik.freehealth.middleware.dto.memberdata.FacetDto
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.domain.memberdata.MemberDataResponse
-import org.taktik.freehealth.middleware.exception.MissingTokenException
+import org.taktik.freehealth.middleware.dto.memberdata.FacetDto
 import org.taktik.freehealth.middleware.service.MemberDataService
 import org.taktik.icure.cin.saml.extensions.Facet
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
-import java.util.Date
-import java.util.UUID
-import javax.servlet.http.HttpServletRequest
+import java.util.*
 
 @RestController
 @RequestMapping("/mda")
@@ -56,19 +41,7 @@ class MemberDataController(val memberDataService: MemberDataService, val mapper:
     @Value("\${mycarenet.timezone}")
     internal val mcnTimezone: String = "Europe/Brussels"
 
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("/{ssin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("/{ssin}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun queryMemberData(
         @PathVariable ssin: String,
         @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/RecipeController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/RecipeController.kt
@@ -20,47 +20,21 @@
 
 package org.taktik.freehealth.middleware.web.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.domain.recipe.Feedback
 import org.taktik.freehealth.middleware.domain.recipe.Prescription
 import org.taktik.freehealth.middleware.domain.recipe.PrescriptionFullWithFeedback
 import org.taktik.freehealth.middleware.dto.Code
 import org.taktik.freehealth.middleware.dto.recipe.PrescriptionRequest
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.RecipeService
 import org.taktik.freehealth.utils.FuzzyValues
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/recipe")
 class RecipeController(val recipeService: RecipeService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@PostMapping("", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @PostMapping("", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun createPrescription(@RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID, @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID, @RequestParam hcpQuality: String, @RequestParam hcpNihii: String, @RequestParam hcpSsin: String, @RequestParam hcpName: String, @RequestHeader(name = "X-FHC-passPhrase") passPhrase: String, @RequestBody prescription: PrescriptionRequest): Prescription =
         recipeService.createPrescription(
             keystoreId = keystoreId,

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/STSController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/STSController.kt
@@ -21,35 +21,17 @@
 package org.taktik.freehealth.middleware.web.controllers
 
 import org.slf4j.LoggerFactory
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import org.taktik.freehealth.middleware.dto.UUIDType
-import org.taktik.freehealth.middleware.exception.MissingKeystoreException
 import org.taktik.freehealth.middleware.service.SSOService
 import org.taktik.freehealth.middleware.service.STSService
-import java.util.UUID
-import javax.servlet.http.HttpServletRequest
+import java.util.*
 
 @RestController
 @RequestMapping("/sts")
 class STSController(private val stsService: STSService, private val ssoService: SSOService) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingKeystoreException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
     val log = LoggerFactory.getLogger(this.javaClass)
 
     @PostMapping("/keystore", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TarificationController.kt
@@ -24,41 +24,18 @@ import com.google.gson.Gson
 import com.sun.xml.messaging.saaj.soap.impl.ElementImpl
 import com.sun.xml.messaging.saaj.soap.ver1_1.DetailEntry1_1Impl
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
-import org.taktik.freehealth.middleware.dto.mycarenet.MycarenetError
+import org.springframework.web.bind.annotation.*
 import org.taktik.freehealth.middleware.dto.etarif.TarificationConsultationResult
-import org.taktik.freehealth.middleware.exception.MissingTokenException
+import org.taktik.freehealth.middleware.dto.mycarenet.MycarenetError
 import org.taktik.freehealth.middleware.service.TarificationService
 import java.time.LocalDateTime
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/tarif")
 class TarificationController(val tarificationService: TarificationService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-private val ConsultTarifErrors =
+    private val ConsultTarifErrors =
         Gson().fromJson(
             this.javaClass.getResourceAsStream("/be/errors/ConsultTarifErrors.json").reader(Charsets.UTF_8),
             arrayOf<MycarenetError>().javaClass

--- a/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TherLinkController.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/web/controllers/TherLinkController.kt
@@ -21,43 +21,18 @@
 package org.taktik.freehealth.middleware.web.controllers
 
 import ma.glasnost.orika.MapperFacade
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseBody
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
-import org.taktik.connector.business.therlink.domain.HasTherapeuticLinkMessage
+import org.springframework.web.bind.annotation.*
 import org.taktik.connector.business.therlink.domain.ProofTypeValues
 import org.taktik.freehealth.middleware.dto.therlink.TherapeuticLinkDto
 import org.taktik.freehealth.middleware.dto.therlink.TherapeuticLinkMessageDto
-import org.taktik.freehealth.middleware.exception.MissingTokenException
 import org.taktik.freehealth.middleware.service.TherLinkService
 import java.util.*
-import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/therlink")
 class TherLinkController(val therLinkService: TherLinkService, val mapper: MapperFacade) {
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(MissingTokenException::class)
-    @ResponseBody
-    fun handleBadRequest(req: HttpServletRequest, ex: Exception): String = ex.message ?: "unknown reason"
-
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    @ExceptionHandler(javax.xml.ws.soap.SOAPFaultException::class)
-    @ResponseBody
-
-fun handleBadRequest(req: HttpServletRequest, ex: javax.xml.ws.soap.SOAPFaultException): String = ex.message ?: "unknown reason"
-
-@GetMapping("/check/{patientSsin}/{hcpNihii}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
+    @GetMapping("/check/{patientSsin}/{hcpNihii}", produces = [MediaType.APPLICATION_JSON_UTF8_VALUE])
     fun hasTherapeuticLink(
         @RequestHeader(name = "X-FHC-keystoreId") keystoreId: UUID,
         @RequestHeader(name = "X-FHC-tokenId") tokenId: UUID,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 spring.application.name=fhc
 server.port=8090
 
-spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.web.servlet.error.ErrorMvcAutoConfiguration
-
 security.filter-order=5
 management.metrics.distribution.percentiles.http.server.requests=0.95,0.99,0.999,1.0
 


### PR DESCRIPTION
`ExceptionHandlers` overrides the default Spring exception resolvers in `WebMvcConfigurer` which means that the custom `@ExceptionHandler`s in controllers are currently not used and the exception messages are never sent.

Also, `ExceptionHandlers` does not return the message as body.

The fix :
- restores the default Spring error handling configuration
- tunes `ExceptionHandlers` and adds `SOAPFaultException` support (`rootException` is not needed anymore, [ExceptionHandlerMethodResolver](https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java#L132) does the job)
- replaces the default Spring error controller to keep the current behavior (text/plain instead of json or html)
- removes custom exception handlers in controllers
- ensures default or custom error controller doesn’t appear in swagger
