### PR TITLE
[MS-3745] suppress the user element in eH2eBox xml payloads

### DIFF
--- a/src/main/kotlin/org/taktik/connector/business/ehbox/v3/builders/SendMessageBuilder.kt
+++ b/src/main/kotlin/org/taktik/connector/business/ehbox/v3/builders/SendMessageBuilder.kt
@@ -33,8 +33,12 @@ import java.util.UUID
 interface SendMessageBuilder {
     @Throws(IOException::class, EhboxBusinessConnectorException::class, TechnicalConnectorException::class)
     fun buildMessage(keystoreId: UUID,
-        keystore: KeyStore,
-        quality: String,
-        passPhrase: String,
-        document: DocumentMessage<Message>): SendMessageRequest
+                     keystore: KeyStore,
+                     quality: String,
+                     passPhrase: String,
+                     document: DocumentMessage<Message>,
+                     // User and Mandate elements are allowed in ehBox messages, but not in eh2Ebox specifications;
+                     // see pg. 9:
+                     // https://www.ehealth.fgov.be/ehealthplatform/file/view/6fe35988ac15c50a85612144deb56533?filename=eH2eBox%20-%20Cookbook%20v1.4%20dd%2020042020.pdf
+                     eH2eBox: Boolean = false): SendMessageRequest
 }

--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EhboxServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EhboxServiceImpl.kt
@@ -196,7 +196,8 @@ class EhboxServiceImpl(private val stsService: STSService, keyDepotService: KeyD
                 stsService.getKeyStore(keystoreId, passPhrase)!!,
                 samlToken.quality,
                 passPhrase,
-                message.toDocumentMessage()
+                message.toDocumentMessage(),
+                true
                                            ).apply {
                 contentContext.contentSpecification.let {
                     it.isPublicationReceipt =


### PR DESCRIPTION
User element is unsupported in DestinationContext for eH2eBox document XML payloads

See page 9:
https://www.ehealth.fgov.be/ehealthplatform/file/view/6fe35988ac15c50a85612144deb56533?filename=eH2eBox%20-%20Cookbook%20v1.4%20dd%2020042020.pdf