### PR TITLE
MS-4480: update enum PersonalStatus matching the enum from iCure-backend

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/domain/common/PersonalStatus.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/domain/common/PersonalStatus.kt
@@ -26,5 +26,5 @@ import java.io.Serializable
 
 @JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 enum class PersonalStatus : Serializable {
-    single, in_couple, married, divorced, widower, complicated, separated, unknown
+    single, in_couple, married, separated, divorced,  divorcing, widowed, widower, complicated, unknown, contract, other
 }


### PR DESCRIPTION
Mismatch between enumeration from iCure-backend (src/main/java/org/taktik/icure/entities/embed/PersonalStatus.java)

`public enum PersonalStatus implements Serializable {
    single, in_couple, married, separated, divorced,  divorcing, widowed, widower, complicated, unknown, contract, other
}`

and from FHC (src/main/kotlin/org/taktik/freehealth/middleware/domain/common/PersonalStatus.kt)

`@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
enum class PersonalStatus : Serializable {
    single, in_couple, married, divorced, widower, complicated, separated, unknown
}`

Could you please regenerate the FHC-API if you accept this PR ?