### PR TITLE
MS-6138:

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/AddressbookServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/AddressbookServiceImpl.kt
@@ -188,7 +188,7 @@ class AddressbookServiceImpl(val stsService: STSService) : AddressbookService {
             ?: org.names.joinToString { it.value },
                                nihii = if (org.id.authenticSource == "NIHII") org.id.value else null,
                                cbe = if (org.id.authenticSource == "CBE") org.id.value else null,
-                               ehp = if (org.id.authenticSource == "EHP") org.id.value else null,
+                               ehp = if (org.id.authenticSource == "EHP" || org.id.authenticSource == "EHP_TEST") org.id.value else null,
                                type = org.organizationTypeCodes?.find { it.type == "code" }?.value,
                                ehealthBoxes = org.eHealthBoxes
         ).apply {


### PR DESCRIPTION
In acceptance medicalhouses/organisations have EHP_TEST as authentic source:
<ns6:OrganizationContactInformation>
	<ns4:Id authenticSource="EHP_TEST" type="HCI">84450277</ns4:Id>
	<ns4:OrganizationTypeCode authenticSource="EHP" type="code">MEDICAL_HOUSE</ns4:OrganizationTypeCode>
	<ns4:OrganizationTypeFriendlyName xml:lang="nl">Medisch huis</ns4:OrganizationTypeFriendlyName>
	<ns4:OrganizationTypeFriendlyName xml:lang="fr">Maison médicale</ns4:OrganizationTypeFriendlyName>
	<ns4:OrganizationTypeFriendlyName xml:lang="de">Medizinhaus</ns4:OrganizationTypeFriendlyName>
	<ns4:Name xml:lang="nl">WIJKGEZONDHEIDSCENTRUM BRUGSE POORT</ns4:Name>
</ns6:OrganizationContactInformation>